### PR TITLE
fix bip44 cointype 0 -> 22

### DIFF
--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -653,7 +653,7 @@ def bip44_derivation(account_id):
     if bitcoin.TESTNET:
         return "m/44'/1'/%d'"% int(account_id)
     else:
-        return "m/44'/0'/%d'"% int(account_id)
+        return "m/44'/22'/%d'"% int(account_id)
 
 def from_seed(seed, passphrase):
     t = seed_type(seed)


### PR DESCRIPTION
please see https://github.com/satoshilabs/slips/blob/master/slip-0044.md
I changed the cointype of bip44 from bitcoin to monacoin.