### PR TITLE
Initialize SimpleConfig singleton for testing.

### DIFF
--- a/electrum_mona/wallet.py
+++ b/electrum_mona/wallet.py
@@ -2190,10 +2190,6 @@ def restore_wallet_from_text(text, *, path,
     storage = WalletStorage(path)
     if storage.file_exists():
         raise Exception("Remove the existing wallet first!")
-        
-    # Load the configurations for this wallet if we don't already have one
-    if SimpleConfig.get_instance() is None:
-        config = SimpleConfig()
 
     text = text.strip()
     if keystore.is_address_list(text):


### PR DESCRIPTION
This patch is to fix the failure when running with tox on Travis CI.
Ported the setUp/tearDown methods from test_blockchain.py of spesmilo/electrum.
Based on comments by ohac at https://twitter.com/ohac/status/1175404287779688449